### PR TITLE
Enabling Workflow permissions

### DIFF
--- a/otterdog/eclipse-aasportal.jsonnet
+++ b/otterdog/eclipse-aasportal.jsonnet
@@ -5,7 +5,8 @@ orgs.newOrg('dt.aasportal', 'eclipse-aasportal') {
     description: "Eclipse AASPortal",
     name: "Eclipse AASPortal",
     workflows+: {
-      actions_can_approve_pull_request_reviews: false,
+      actions_can_approve_pull_request_reviews: true,
+      default_workflow_permissions: "write"
     },
   },
   _repositories+:: [


### PR DESCRIPTION
Background is that we would like to run automatic gh-page generation.

When we are currently doing that, at the end we get 

```
Push the commit or tag
  /usr/bin/git push origin gh-pages
  remote: Permission to eclipse-aasportal/AASPortal.git denied to github-actions[bot].
  fatal: unable to access 'https://github.com/eclipse-aasportal/AASPortal.git/': The requested URL returned error: 403
``` 
(https://github.com/eclipse-aasportal/AASPortal/actions/runs/16804608175/job/47593753088)

